### PR TITLE
added link to open the monzo auth page needed to get credentials

### DIFF
--- a/MonzoBalance/AppDelegate.swift
+++ b/MonzoBalance/AppDelegate.swift
@@ -21,6 +21,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var credentials = MonzoCredentials(accountId: "", accessToken: "")
     // END
     
+    @IBAction func emailMagicLink(_ sender: Any) {
+        if let url = URL(string: "https://auth.monzo.com/?redirect_uri=https%3A%2F%2Fdevelopers.monzo.com%2Flogin%3Fredirect%3D%252Fapi%252Fplayground&client_id=oauthclient_000094PvINDGzT3k6tz8jp&response_type=code"),
+            NSWorkspace.shared.open(url) {
+        }
+    }
+    
     func setCredentials(newCredentials: MonzoCredentials) -> Void {
         if newCredentials.accessToken != "" {
             

--- a/MonzoBalance/Base.lproj/MainMenu.xib
+++ b/MonzoBalance/Base.lproj/MainMenu.xib
@@ -28,6 +28,9 @@
                 <menuItem isSeparatorItem="YES" id="mbp-6i-561"/>
                 <menuItem title="Email me my credentials" id="khM-7E-shX">
                     <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="emailMagicLink:" target="Voe-Tx-rLC" id="c7C-qR-R9y"/>
+                    </connections>
                 </menuItem>
                 <menuItem title="Enter credentials manually" id="XcP-rW-Vyo">
                     <modifierMask key="keyEquivalentModifierMask"/>


### PR DESCRIPTION
This is a half way measure on the way to getting the app to be able to fully authenticate with Monzo.

I'm not sure this is 100% achievable but it's definately worth a try because it would save a lot of clicks

What I've done so far saves some clicks but not nearly enough